### PR TITLE
Character codes are now correctly sent to new S-Lang

### DIFF
--- a/mapslang/main.c
+++ b/mapslang/main.c
@@ -274,6 +274,7 @@ void get_command_line_options(struct SCRMODE_DATA *scrmode,struct WORKMODE_DATA 
  */
 int main(int argc, char **argv)
 {
+    SLutf8_enable(1);
     struct SCRMODE_DATA *scrmode;
     struct WORKMODE_DATA workdata;
     // Initialize the message displaying and storing

--- a/mapslang/output_scr.c
+++ b/mapslang/output_scr.c
@@ -107,7 +107,7 @@ void screen_printf_toeol(char *format, ...)
 void screen_printchr(char dst)
 {
     if (!screen_initied) return;
-    SLsmg_write_char(dst);
+    SLsmg_write_char((unsigned char)dst);
 }
 
 void screen_clear(void)


### PR DESCRIPTION
Fixes #6 - characters are now correctly sent to new S-Lang

This patch:
- Enables UTF-8 mode in libslang
- Casts the char sent to SLsmg_write_char() as an unsigned char
- **Doing this fixes the drawing of lines with mapslang** (Sending the charcode for any character from code page 850 over 176 works for me).

An `unsigned char` matches `SLuchar_Type` from slang, the precise reason that this works is unknown to me right now. **_Looking through SLsmg_write_chars() in slsmg.c should lead to an answer. <- I don't mind if someone else beats me to it!_**

I'm not sure what determines the codepage here, or if it is compile time, or run time.

These changes do not cause an issue if you use map.exe (with these changes) with the older libslang.dll from 0.95

Result:
![image](https://user-images.githubusercontent.com/1984342/94986598-ecea3e00-0557-11eb-9deb-113c77608f90.png)
