### PR TITLE
Issue 26: prevent closing file in function not 'owning' the file

### DIFF
--- a/libadikted/bulcommn.c
+++ b/libadikted/bulcommn.c
@@ -215,7 +215,6 @@ short write_bmp_fp_24b(FILE *out, int width, int height, const char *data)
         }
     }
     
-    /* fclose (out); */                                             /* fixes UB, moreover callers of function should close the file */
     return 0;
 }
 

--- a/libadikted/bulcommn.c
+++ b/libadikted/bulcommn.c
@@ -215,7 +215,7 @@ short write_bmp_fp_24b(FILE *out, int width, int height, const char *data)
         }
     }
     
-    fclose (out);
+    /* fclose (out); */                                             /* fixes UB, moreover callers of function should close the file */
     return 0;
 }
 


### PR DESCRIPTION
File is opened outside of `write_bmp_fp_24b` function, so function should not be it's responsibility to close it. Moreover currently file is closed after every call to `write_bmp_fp_24b` function, it means file is always closed two times, leading to undefined behaviour.