### PR TITLE
'write_lif()': properly handle full path with digits

### DIFF
--- a/libadikted/lev_files.c
+++ b/libadikted/lev_files.c
@@ -1278,6 +1278,19 @@ short write_wlb(struct LEVEL *lvl,char *fname)
 }
 
 /**
+ * Wrapper around 'strrchr()'. Tries to find last occurrence of 'item' in 'buffer.
+ * @return Returns pointer to last 'item' in 'buffer' on success, otherwise 'buffer'.
+ */
+static char* find_last( char *buffer, const char item )
+{
+    char *found = strrchr( buffer, item );
+    if ( found != NULL ) {
+        return found;
+    }
+    return buffer;
+}
+
+/**
  * Writes the LIF file from LEVEL structure into disk.
  * LIFs are used to save text name of the level.
  * @param lvl Pointer to the LEVEL structure.
@@ -1289,18 +1302,11 @@ short write_lif(struct LEVEL *lvl,char *fname)
   message_log(" write_lif: starting");
   /*Acquiring map number */
   long lvl_num;
+  char *fname_num = fname;
 
-  /**
-   * Start detecting digits counting from position of last slash ('/').
-   * It fulfills case when given 'fname' contains full path to file and
-   * that path contains digits in directory names, e.g.:
-   *    '/path/to/game/keeperfx_0_4_8/levels/map00123.lit'.
-   * In following case desired number is '123', but algorithm wrongly finds '0'.
-   */
-  char *fname_num = strrchr( fname, '/' );
-  if ( fname_num == NULL ) {
-      fname_num = fname;
-  }
+  /* Separating filename from directory subpath */
+  fname_num = find_last( fname_num, '/' );                 /* Linux path separator */
+  fname_num = find_last( fname_num, '\\' );                /* Windows path separator */
 
   while ( ((*fname_num)!='\0') && (!isdigit(*fname_num)) ) fname_num++;
   lvl_num=atol(fname_num);

--- a/libadikted/lev_files.c
+++ b/libadikted/lev_files.c
@@ -1289,8 +1289,20 @@ short write_lif(struct LEVEL *lvl,char *fname)
   message_log(" write_lif: starting");
   /*Acquiring map number */
   long lvl_num;
-  char *fname_num=fname;
-  while (((*fname_num)!='\0')&&(!isdigit(*fname_num))) fname_num++;
+
+  /**
+   * Start detecting digits counting from position of last slash ('/').
+   * It fulfills case when given 'fname' contains full path to file and
+   * that path contains digits in directory names, e.g.:
+   *    '/path/to/game/keeperfx_0_4_8/levels/map00123.lit'.
+   * In following case desired number is '123', but algorithm wrongly finds '0'.
+   */
+  char *fname_num = strrchr( fname, '/' );
+  if ( fname_num == NULL ) {
+      fname_num = fname;
+  }
+
+  while ( ((*fname_num)!='\0') && (!isdigit(*fname_num)) ) fname_num++;
   lvl_num=atol(fname_num);
   /*Creating text lines */
   char **lines=(char **)malloc(2*sizeof(char *));


### PR DESCRIPTION
In most cases `write_lif()` handles relative paths from game's main directory assuming that level number is the first number found in file path, therefore handling of full paths containing numbers is improper. For example for given path '/path/to/game/keeperfx_0_4_8/levels/map00123.lit' algorithm detects '0', but should find '123'. The change handles this case by finding last slash (beginning of file name without subdirectories).
To reproduce the error set field `LEVEL::savfname` value to path with directories containing numbers and write map to file.
