### PR TITLE
Fix copying string: make function invulnerable to garbage in allocated memory

### DIFF
--- a/libadikted/arr_utils.c
+++ b/libadikted/arr_utils.c
@@ -234,7 +234,7 @@ char *prepare_short_fname(const char *fname, unsigned int maxlen)
         message_error("prepare_short_fname: Cannot allocate memory.");
         return NULL;
     }
-    strncpy(retname,start,strlen(retname));
+    strncpy( retname, start, len );
     retname[len]='\0';
     return retname;
 }

--- a/libadikted/arr_utils.c
+++ b/libadikted/arr_utils.c
@@ -224,18 +224,14 @@ char *prepare_short_fname(const char *fname, unsigned int maxlen)
     unsigned int len=strlen(start);
     if (len > maxlen)
           len=maxlen;
-    char *retname;
+    char *retname = NULL;
     if (len>0)
-        retname=(char *)malloc(len+1);
-    else
-        retname=NULL;
+        retname = strndup( start, len );
     if (retname==NULL)
     {
         message_error("prepare_short_fname: Cannot allocate memory.");
         return NULL;
     }
-    strncpy( retname, start, len );
-    retname[len]='\0';
     return retname;
 }
 

--- a/libadikted/arr_utils.c
+++ b/libadikted/arr_utils.c
@@ -224,14 +224,18 @@ char *prepare_short_fname(const char *fname, unsigned int maxlen)
     unsigned int len=strlen(start);
     if (len > maxlen)
           len=maxlen;
-    char *retname = NULL;
+    char *retname;
     if (len>0)
-        retname = strndup( start, len );
+        retname=(char *)malloc(len+1);
+    else
+        retname=NULL;
     if (retname==NULL)
     {
         message_error("prepare_short_fname: Cannot allocate memory.");
         return NULL;
     }
+    strncpy( retname, start, len );
+    retname[len]='\0';
     return retname;
 }
 


### PR DESCRIPTION
In function `prepare_short_fname()` there is problem of taking string length of uninitialized memory. It leads to returning improper (shorter than expected) file name. Bogus case occurs when uninitialized block of memory (string) accidentally contains `\0` in middle of memory block.

To reproduce the bug try to save map giving reasonably long name (smaller than 24 characters), e.g. `map12345`, then observe file `map12345.adi` for invalid short name written in first line, e.g. `REM ADiKtEd script file for map123` (it should contain full name: `map12345`) . Reproducing bug might require several attempts, because of involved randomness (memory garbage).
