### PR TITLE
level_verify: select steps to proceed

### DIFF
--- a/libadikted/lev_data.c
+++ b/libadikted/lev_data.c
@@ -1184,48 +1184,51 @@ struct DK_SCRIPT_PARAMETERS *level_get_script_param(struct LEVEL *lvl)
  * @return Returns VERIF_ERROR, VERIF_WARN or VERIF_OK.
  *     If a problem was found, adds error message and sets errpt accordingly.
  */
-short level_verify(struct LEVEL *lvl, char *actn_name,struct IPOINT_2D *errpt)
-{
+short level_verify(struct LEVEL *lvl, char *actn_name,struct IPOINT_2D *errpt) {
+    return level_verify_control( lvl, actn_name, 0, errpt );
+}
+
+short level_verify_control(struct LEVEL *lvl, char *actn_name, unsigned long skip_step_flags, struct IPOINT_2D *errpt) {
   char err_msg[LINEMSG_SIZE];
   strcpy(err_msg,"Unknown error");
   short result=VERIF_OK;
   short nres;
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_STRUCT) )
   {
     nres=level_verify_struct(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;
   }
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_THINGS) )
   {
     nres=things_verify(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;
   }
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_SLABS) )
   {
     nres=slabs_verify(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;
   }
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_ACTNPNTS) )
   {
     nres=actnpts_verify(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;
   }
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_COLUMNS) )
   {
     nres=columns_verify(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;
   }
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_DAT) )
   {
     nres=dat_verify(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;
   }
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_TXT) )
   {
     nres=txt_verify(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;
   }
-  if (result!=VERIF_ERROR)
+  if ( result!=VERIF_ERROR && !(skip_step_flags & VSF_LOGIC) )
   {
     nres=level_verify_logic(lvl,err_msg,errpt);
     if (nres!=VERIF_OK) result=nres;

--- a/libadikted/lev_data.h
+++ b/libadikted/lev_data.h
@@ -59,6 +59,18 @@ enum VERIFY_WARN_FLAGS {
 /*     VWFLAG_NOWARN_           =  2, */
      };
 
+/* Select level verification steps to skip (bit fields) */
+enum VERIFY_SKIP_FLAGS {
+    VSF_STRUCT      = 0x01,
+    VSF_THINGS      = VSF_STRUCT    << 1,
+    VSF_SLABS       = VSF_THINGS    << 1,
+    VSF_ACTNPNTS    = VSF_SLABS     << 1,
+    VSF_COLUMNS     = VSF_ACTNPNTS  << 1,
+    VSF_DAT         = VSF_COLUMNS   << 1,
+    VSF_TXT         = VSF_DAT       << 1,
+    VSF_LOGIC       = VSF_TXT       << 1
+};
+
 /*Disk files entries */
 
 #define SIZEOF_DK_TNG_REC 21
@@ -389,6 +401,7 @@ DLLIMPORT short level_free_script_param(struct DK_SCRIPT_PARAMETERS *par);
 DLLIMPORT short free_text_file(char ***lines,int *lines_count);
 
 DLLIMPORT short level_verify(struct LEVEL *lvl, char *actn_name,struct IPOINT_2D *errpt);
+DLLIMPORT short level_verify_control(struct LEVEL *lvl, char *actn_name, unsigned long skip_step_flags, struct IPOINT_2D *errpt);
 DLLIMPORT short level_verify_struct(struct LEVEL *lvl, char *err_msg,struct IPOINT_2D *errpt);
 short actnpts_verify(struct LEVEL *lvl, char *err_msg,struct IPOINT_2D *errpt);
 DLLIMPORT short level_verify_logic(struct LEVEL *lvl, char *err_msg,struct IPOINT_2D *errpt);


### PR DESCRIPTION
Control which 'level_verify()' steps to proceed. Useful to disable Txt (script) verification in case script containing new/prototype commands.