### PR TITLE
allow saving custom sized maps

### DIFF
--- a/libadikted/lev_data.c
+++ b/libadikted/lev_data.c
@@ -2403,8 +2403,8 @@ short get_slx_tileset(const struct LEVEL *lvl, unsigned int tx, unsigned int ty)
 {
     if (lvl->slb==NULL) return 0;
     /*Bounding position */
-    if ( (tx >= MAP_SIZE_DKSTD_X) || (ty >= MAP_SIZE_DKSTD_Y) ) return 0;
-    return (lvl->slx_data[tx + ty * MAP_SIZE_DKSTD_Y] & 0x0F);
+    if ( (tx >= lvl->tlsize.x) || (ty >= lvl->tlsize.y) ) return 0;
+    return (lvl->slx_data[tx + ty * lvl->tlsize.x] & 0x0F);
 }
 
 /**
@@ -2417,9 +2417,9 @@ short get_slx_tileset(const struct LEVEL *lvl, unsigned int tx, unsigned int ty)
 void set_slx_tileset(struct LEVEL *lvl, unsigned int tx, unsigned int ty, unsigned short nval)
 {
     /*Bounding position */
-    if ( (tx >= MAP_SIZE_DKSTD_X) || (ty >= MAP_SIZE_DKSTD_Y) ) return;
-    lvl->slx_data[tx + ty * MAP_SIZE_DKSTD_Y] &= 0xF0;
-    lvl->slx_data[tx + ty * MAP_SIZE_DKSTD_Y] |= nval & 0x0F;
+    if ( (tx >= lvl->tlsize.x) || (ty >= lvl->tlsize.y) ) return;
+    lvl->slx_data[tx + ty * lvl->tlsize.x] &= 0xF0;
+    lvl->slx_data[tx + ty * lvl->tlsize.x] |= nval & 0x0F;
 }
 
 /**

--- a/libadikted/lev_data.h
+++ b/libadikted/lev_data.h
@@ -24,6 +24,8 @@
 
 #define MAP_SIZE_DKSTD_X 85
 #define MAP_SIZE_DKSTD_Y 85
+#define MAX_MAP_SIZE_DKXPAND_X 500
+#define MAX_MAP_SIZE_DKXPAND_Y 500
 #define MAP_SIZE_H 1
 #define MAP_SUBNUM_H 8
 #define MAP_SUBNUM_X 3
@@ -369,7 +371,7 @@ struct LEVEL {
     struct DK_GRAFFITI **graffiti;
     unsigned int graffiti_count;
 
-    unsigned char slx_data[MAP_SIZE_DKSTD_X * MAP_SIZE_DKSTD_Y];
+    unsigned char slx_data[MAX_MAP_SIZE_DKXPAND_X * MAX_MAP_SIZE_DKXPAND_Y];
   };
 
 extern const char default_map_name[];

--- a/libadikted/lev_files.c
+++ b/libadikted/lev_files.c
@@ -1336,7 +1336,7 @@ short write_lof(struct LEVEL *lvl,char *fname)
     message_log(" write_lof: starting");
 
     /*Creating text lines */
-    char **lines=(char **)malloc(2*sizeof(char *));
+    char **lines=(char **)malloc(13*sizeof(char *));
     int lines_count=0;
     for (size_t i = 0; i < 13; i++)
     {

--- a/libadikted/lev_files.c
+++ b/libadikted/lev_files.c
@@ -1324,6 +1324,73 @@ short write_lif(struct LEVEL *lvl,char *fname)
 }
 
 /**
+ * Writes the LOF file from LEVEL structure into disk.
+ * LOFs are used to save text name of the level and some extra data like mapsize etc
+ * only in extended format.
+ * @param lvl Pointer to the LEVEL structure.
+ * @param fname Destination file name.
+ * @return Returns ERR_NONE on success, error code on failure.
+ */
+short write_lof(struct LEVEL *lvl,char *fname)
+{
+    message_log(" write_lof: starting");
+
+    /*Creating text lines */
+    char **lines=(char **)malloc(2*sizeof(char *));
+    int lines_count=0;
+    for (size_t i = 0; i < 13; i++)
+    {
+        lines[i]=malloc(LINEMSG_SIZE+1);
+    }
+    
+    sprintf(lines[lines_count],"; KeeperFX Level Overview File (LOF)");
+    lines_count++;
+    char* nameText = get_lif_name_text(lvl);
+    sprintf(lines[lines_count],"NAME_TEXT = %s",nameText);
+    lines_count++;
+    char* nameId = "";
+    sprintf(lines[lines_count],"NAME_ID = %s",nameId);
+    lines_count++;
+    char* kind = "";
+    sprintf(lines[lines_count],"KIND = %s",kind);
+    lines_count++;
+    char* ensignPos = "";
+    sprintf(lines[lines_count],"ENSIGN_POS = %s",ensignPos);
+    lines_count++;
+    char* ensignZoom = "";
+    sprintf(lines[lines_count],"ENSIGN_ZOOM = %s",ensignZoom);
+    lines_count++;
+    char* Players = "";
+    sprintf(lines[lines_count],"PLAYERS = %s",Players);
+    lines_count++;
+    char* Options = "";
+    sprintf(lines[lines_count],"OPTIONS = %s",Options);
+    lines_count++;
+    char* Speech = "";
+    sprintf(lines[lines_count],"SPEECH = %s",Speech);
+    lines_count++;
+    char* landView = "";
+    sprintf(lines[lines_count],"LAND_VIEW = %s",landView);
+    lines_count++;
+    char* author = lvl->info.author_text;
+    if (author==NULL) author="";
+    sprintf(lines[lines_count],"AUTHOR = %s",author);
+    lines_count++;
+    char* description = lvl->info.desc_text;
+    if (description==NULL) description="";
+    sprintf(lines[lines_count],"DESCRIPTION = %s",description);
+    lines_count++;
+    sprintf(lines[lines_count],"MAPSIZE = %d %d",lvl->tlsize.x,lvl->tlsize.y);
+    lines_count++;
+
+    short result;
+    result=write_text_file(lines,lines_count,fname);
+    text_file_free(lines,lines_count);
+    return result;
+
+}
+
+/**
  * Writes the ADI script file from LEVEL structure into disk.
  * Creates the file data first it - is not stored directly in LEVEL.
  * @param lvl Pointer to the LEVEL structure.
@@ -1496,7 +1563,7 @@ short write_slx(struct LEVEL *lvl,char *fname)
   FILE* fp = fopen(fname, "wb");
   if (fp==NULL)
     return ERR_CANT_OPENWR;
-  fwrite(lvl->slx_data, sizeof(lvl->slx_data), 1, fp);
+  fwrite(lvl->slx_data, lvl->tlsize.x * lvl->tlsize.y, 1, fp);
   fclose(fp);
   return ERR_NONE;
 }
@@ -1633,39 +1700,39 @@ short save_dke_map(struct LEVEL *lvl)
     int saved_files=0;
     int total_files=0;
 
-      message_error("Error: Save not supported for extender map format");
-      result=ERR_INTERNAL;
-/*
-    save_mapfile(lvl,"slb",write_slb,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"slb",write_slb,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"own",write_own,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"own",write_own,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"dat",write_dat,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"dat",write_dat,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"clm",write_clm,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"clm",write_clm,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"tng",write_tng,&saved_files,&result);
+    //TODO replace with tngfx
+    save_mapfile(lvl,lvl->savfname,"tng",write_tng,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"apt",write_apt,&saved_files,&result);
+    //TODO replace with aptfx
+    save_mapfile(lvl,lvl->savfname,"apt",write_apt,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"wib",write_wib,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"wib",write_wib,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"inf",write_inf,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"inf",write_inf,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"txt",write_txt,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"txt",write_txt,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"lgt",write_lgt,&saved_files,&result);
+    //TODO replace with lgtfx
+    save_mapfile(lvl,lvl->savfname,"lgt",write_lgt,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"wlb",write_wlb,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"wlb",write_wlb,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"flg",write_flg,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"flg",write_flg,&saved_files,&result);
     total_files++;
-    save_mapfile(lvl,"lif",write_lif,&saved_files,&result);
+    save_mapfile(lvl,lvl->savfname,"lof",write_lof,&saved_files,&result);
     total_files++;
-*/
-    save_mapfile(lvl,lvl->savfname,"vsn",write_vsn,&saved_files,&result);
-    total_files++;
+
     save_mapfile(lvl,lvl->savfname,"adi",write_adi_script,&saved_files,&result);
+    total_files++;
+    save_mapfile(lvl,lvl->savfname,"slx",write_slx,&saved_files,&result);
     total_files++;
 
     if ((result==ERR_NONE)||(strlen(lvl->fname)<1))
@@ -2017,14 +2084,14 @@ short load_dke_map(struct LEVEL *lvl)
   if (result>=ERR_NONE)
       load_mapfile(lvl,"own",load_own,&loaded_files,&result,LFF_IGNORE_NONE);
   if (result>=ERR_NONE)
-      load_mapfile(lvl,"tng",load_tng,&loaded_files,&result,LFF_IGNORE_NONE);
+      load_mapfile(lvl,"tngfx",load_tngfx,&loaded_files,&result,LFF_IGNORE_NONE);
   /* Less importand files */
   if (result>=ERR_NONE)
       load_mapfile(lvl,"dat",load_dat,&loaded_files,&result,LFF_IGNORE_ALL);
   if (result>=ERR_NONE)
-      load_mapfile(lvl,"apt",load_apt,&loaded_files,&result,LFF_IGNORE_ALL);
+      load_mapfile(lvl,"aptfx",load_aptfx,&loaded_files,&result,LFF_IGNORE_ALL);
   if (result>=ERR_NONE)
-      load_mapfile(lvl,"lgt",load_lgt,&loaded_files,&result,LFF_IGNORE_ALL);
+      load_mapfile(lvl,"lgtfx",load_lgtfx,&loaded_files,&result,LFF_IGNORE_ALL);
   if (result>=ERR_NONE)
       load_mapfile(lvl,"clm",load_clm,&loaded_files,&result,LFF_IGNORE_ALL);
   if (result>=ERR_NONE)
@@ -2040,10 +2107,12 @@ short load_dke_map(struct LEVEL *lvl)
   if (result>=ERR_NONE)
       load_mapfile(lvl,"flg",load_flg,&loaded_files,&result,LFF_IGNORE_WITHOUT_WARN);
   if (result>=ERR_NONE)
-      load_mapfile(lvl,"lif",load_lif,&loaded_files,&result,LFF_IGNORE_WITHOUT_WARN);
+      load_mapfile(lvl,"lof",load_lof,&loaded_files,&result,LFF_IGNORE_WITHOUT_WARN);
 #endif
   if (result>=ERR_NONE)
       load_mapfile(lvl,"vsn",load_vsn,&loaded_files,&result,LFF_IGNORE_WITHOUT_WARN);
+  if (result>=ERR_NONE)
+      load_mapfile(lvl,"slx",load_slx,&loaded_files,&result,LFF_IGNORE_WITHOUT_WARN);
   if (result>=ERR_NONE)
       load_mapfile_msg(lvl,"adi",script_load_and_execute,&loaded_files,&result,LFF_IGNORE_WITHOUT_WARN);
   if (result<ERR_NONE)

--- a/libadikted/lev_files.c
+++ b/libadikted/lev_files.c
@@ -1351,7 +1351,7 @@ short write_lof(struct LEVEL *lvl,char *fname)
     char* nameId = "";
     sprintf(lines[lines_count],"NAME_ID = %s",nameId);
     lines_count++;
-    char* kind = "";
+    char* kind = "FREE";
     sprintf(lines[lines_count],"KIND = %s",kind);
     lines_count++;
     char* ensignPos = "";


### PR DESCRIPTION
enable saves for the DK Extended map format, which'll now use LOF files
fix slx not taking mapsize in to consideration

only allows saving, no loading atm
only for the libadikted dll, nothing changed on the slang side

also only square maps seem to work, didn't look into why

doesn't use the tngfx lgtfx and aptfx files yet